### PR TITLE
Update to use Frama-C v29

### DIFF
--- a/packages/auto-deduct/auto-deduct.dev/opam
+++ b/packages/auto-deduct/auto-deduct.dev/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/rse-verification/auto-deduct-toolchain/issues"
 authors: ["The Autodeduct development team"]
 license: "GPL-2.0-or-later"
 depends: [
-  "frama-c" {= "28.1"}
+  "frama-c" {= "29.0"}
   "frama-c-isp" {= "dev"}
   "frama-c-saida" {= "dev"}
   "tricera" {= "0.3.1"}

--- a/packages/frama-c-isp/frama-c-isp.dev/opam
+++ b/packages/frama-c-isp/frama-c-isp.dev/opam
@@ -11,8 +11,8 @@ homepage:
 bug-reports: "https://github.com/rse-verification/interface-specification-propagator/issues"
 depends: [
   "dune" {>= "3.2"}
-  "ocaml" {>= "4.14"}
-  "frama-c" {>= "26" & < "29"}
+  "ocaml" {>= "4.13.1"}
+  "frama-c" {>= "29"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/frama-c-saida/frama-c-saida.dev/opam
+++ b/packages/frama-c-saida/frama-c-saida.dev/opam
@@ -10,8 +10,8 @@ homepage: "https://github.com/rse-verification/saida"
 bug-reports: "https://github.com/rse-verification/saida/issues"
 depends: [
   "dune" {>= "3.2"}
-  "ocaml" {>= "4.14"}
-  "frama-c" {>= "26" & < "29"}
+  "ocaml" {>= "4.13.1"}
+  "frama-c" {>= "29"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This PR updates packages to use Frama-C version 29. 